### PR TITLE
Change key names in json post body

### DIFF
--- a/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics4.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics4.java
@@ -46,16 +46,16 @@ final class GoogleAnalytics4 extends AbstractGoogleAnalytics implements Analytic
                           @NotNull final Map<String, String> userProperties) {
         return Stream.of(
                 "{",
-                jsonElement(" ", "clientId", clientId) + ',',
-                jsonElement(" ", "userId", clientId) + ',',
-                jsonElement(" ", "nonPersonalizedAds", true) + ',',
+                jsonElement(" ", "client_id", clientId) + ',',
+                jsonElement(" ", "user_id", clientId) + ',',
+                jsonElement(" ", "non_personalized_ads", true) + ',',
                 ' ' + asElement("events") + ": [{",
                 jsonElement("  ", "name", eventName) + ',',
                 "  " + asElement("params") + ": {",
                 renderMap(eventParameters, e -> jsonElement("   ", e.getKey(), e.getValue())),
                 "  }",
                 " }],",
-                ' ' + asElement("userProperties") + ": {",
+                ' ' + asElement("user_properties") + ": {",
                 renderMap(userProperties, GoogleAnalytics4::userProperty),
                 " }",
                 "}"

--- a/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalyticsTest.java
@@ -37,9 +37,9 @@ final class GoogleAnalyticsTest {
     @Test
     void jsonFor() {
         final String expected = "{\n" +
-                " 'clientId': '123',\n" +
-                " 'userId': '123',\n" +
-                " 'nonPersonalizedAds': true,\n" +
+                " 'client_id': '123',\n" +
+                " 'user_id': '123',\n" +
+                " 'non_personalized_ads': true,\n" +
                 " 'events': [{\n" +
                 "  'name': 'started',\n" +
                 "  'params': {\n" +
@@ -47,7 +47,7 @@ final class GoogleAnalyticsTest {
                 "   'B': '2'\n" +
                 "  }\n" +
                 " }],\n" +
-                " 'userProperties': {\n" +
+                " 'user_properties': {\n" +
                 "  'C': {\n" +
                 "    'value': '3'\n" +
                 "  },\n" +


### PR DESCRIPTION
Changed key names from camel case to snake case in JSON post body to match latest Measurement Protocol (GA4) specification.

See JSON post body table:
https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference?client_type=gtag#payload_post_body
