### PR TITLE
Add `code-review` profile (Checkstyle/PMD/SpotBugs/JaCoCo), raise coverage, and harden Chronicle Analytics

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,15 +8,13 @@ Per Minborg
 :toc-title: Table of contents
 
 image:https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-analytics/badge.svg[Maven Central,link=https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-analytics]
-image:https://javadoc-badge.appspot.com/net.openhft/chronicle-analytics.svg?label=javadoc[JavaDoc, link=https://www.javadoc.io/doc/net.openhft/chronicle-analytics]
-image:https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000[License, link=https://github.com/OpenHFT/Chronicle-Analytics/blob/master/LICENSE]
+image:https://javadoc-badge.appspot.com/net.openhft/chronicle-analytics.svg?label=javadoc[JavaDoc,link=https://www.javadoc.io/doc/net.openhft/chronicle-analytics]
+image:https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000[License,link=https://github.com/OpenHFT/Chronicle-Analytics/blob/master/LICENSE]
 image:https://img.shields.io/gitter/room/OpenHFT/Lobby.svg?style=popout[link="https://gitter.im/OpenHFT/Lobby"]
 
-This library provides remote ingress to Google Analytics 4, allowing data, such as usage-statistics, to be collected for Java applications.The data can subsequently be analysed using
-a variety of tools available from Google and other providers.
+This library provides remote ingress to Google Analytics 4, allowing data, such as usage-statistics, to be collected for Java applications.The data can subsequently be analysed using a variety of tools available from Google and other providers.
 
-Here is a short Java snippet showing how one could use the library to send a Google Analytics event
-for the measurement id "G-TDAZG4CU3G" using the api secret "k2hL3x2dQaKq9F2gQ-PNhQ".
+Here is a short Java snippet showing how one could use the library to send a Google Analytics event for the measurement id "G-TDAZG4CU3G" using the api secret "k2hL3x2dQaKq9F2gQ-PNhQ".
 
 [source,java]
 ----
@@ -35,7 +33,7 @@ toc::[]
 Under `noop` there is a build for an empty jar which when included will ensure this jar does nothing.
 This jar is redundant but can help ensure this jar does nothing.
 
-To disable this jar include the following in Maven: 
+To disable this jar include the following in Maven:
 
 [script,xml]
 ----
@@ -45,7 +43,7 @@ To disable this jar include the following in Maven:
     <version>0.20.0</version>
 ----
 
-To disable this library with Gradle, use: 
+To disable this library with Gradle, use:
 
 [script,xml]
 ----
@@ -125,7 +123,7 @@ NOTE: See the link:https://javadoc.io/doc/net.openhft/chronicle-analytics/latest
 The following example sets up an analytics instance with the *event parameter* `app_version = 1.4.2` and perhaps the *user properties*
 `os_name = Linux`, `os_version = 4.18.0.147.2.1.2l8_1.x86_64` and `java_runtime_version = 1.8.0_272-b10` depending on the environment used:
 
-[source, java]
+[source,java]
 ----
 public class AnalyticsExampleMain {
 
@@ -172,7 +170,9 @@ The library does not have any transitive dependencies and depends directly only 
 
 === JSON compliance
 
-The library supports basic JSON functionality. Escaping works for the most common characters used in the English language. To keep the dependency graph simple, we did not depend on any external JSON library.
+The library supports basic JSON functionality.
+Escaping works for the most common characters used in the English language.
+To keep the dependency graph simple, we did not depend on any external JSON library.
 
 === Thread safety
 
@@ -180,8 +180,10 @@ Analytics instances are thread-safe and can be shared across threads.
 
 === Thread usage
 
-The library is using a single thread named `"chronicle-analytics-http-client"` to send requests. This thread is initially started on demand and will remain dormant throughout the lifespan of the JVM.
+The library is using a single thread named `"chronicle-analytics-http-client"` to send requests.
+This thread is initially started on demand and will remain dormant throughout the lifespan of the JVM.
 
 === Special empty version
 
-There is a special empty artifact available with the version number `0.EMPTY`. This version can be used to remove analytics code from projects that depends on analytics.
+There is a special empty artifact available with the version number `0.EMPTY`.
+This version can be used to remove analytics code from projects that depends on analytics.

--- a/noop/pom.xml
+++ b/noop/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/noop/pom.xml
+++ b/noop/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>1.27ea0</version>
+        <version>1.27ea1</version>
         <relativePath/>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,18 @@
     <description>Chronicle-Analytics</description>
     <packaging>bundle</packaging>
 
+    <properties>
+        <checkstyle.version>3.6.0</checkstyle.version>
+        <puppycrawl.version>10.26.1</puppycrawl.version>
+        <spotbugs.version>4.9.8.1</spotbugs.version>
+        <findsecbugs.version>1.14.0</findsecbugs.version>
+        <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
+        <jacoco.line.coverage>0.80</jacoco.line.coverage>
+        <jacoco.branch.coverage>0.70</jacoco.branch.coverage>
+        <chronicle-quality-rules.version>1.23ea6</chronicle-quality-rules.version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -48,6 +60,13 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.9.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->
@@ -267,6 +286,147 @@
                                 </resource>
                             </resources>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>code-review</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <version>${checkstyle.version}</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.puppycrawl.tools</groupId>
+                                <artifactId>checkstyle</artifactId>
+                                <version>${puppycrawl.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>net.openhft</groupId>
+                                <artifactId>chronicle-quality-rules</artifactId>
+                                <version>${chronicle-quality-rules.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>checkstyle</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <configLocation>net/openhft/quality/checkstyle/checkstyle.xml</configLocation>
+                            <consoleOutput>true</consoleOutput>
+                            <failOnViolation>true</failOnViolation>
+                            <violationSeverity>warning</violationSeverity>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
+                        <version>${spotbugs.version}</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.h3xstream.findsecbugs</groupId>
+                                <artifactId>findsecbugs-plugin</artifactId>
+                                <version>${findsecbugs.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>spotbugs</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <effort>Max</effort>
+                            <threshold>Low</threshold>
+                            <failOnError>true</failOnError>
+                            <excludeFilterFile>src/main/config/spotbugs-exclude.xml</excludeFilterFile>
+                            <plugins>
+                                <plugin>
+                                    <groupId>com.h3xstream.findsecbugs</groupId>
+                                    <artifactId>findsecbugs-plugin</artifactId>
+                                    <version>${findsecbugs.version}</version>
+                                </plugin>
+                            </plugins>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <version>${maven-pmd-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>pmd</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <failOnViolation>true</failOnViolation>
+                            <printFailingErrors>true</printFailingErrors>
+                            <excludeFromFailureFile>src/main/config/pmd-exclude.properties</excludeFromFailureFile>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>check</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <rule>
+                                            <element>BUNDLE</element>
+                                            <limits>
+                                                <limit>
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${jacoco.line.coverage}</minimum>
+                                                </limit>
+                                                <limit>
+                                                    <counter>BRANCH</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>${jacoco.branch.coverage}</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -63,13 +63,6 @@
             <artifactId>annotations</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-annotations</artifactId>
-            <version>4.9.0</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <jacoco.line.coverage>0.80</jacoco.line.coverage>
-        <jacoco.branch.coverage>0.70</jacoco.branch.coverage>
+        <jacoco.line.coverage>0.898</jacoco.line.coverage>
+        <jacoco.branch.coverage>0.7142857</jacoco.branch.coverage>
         <chronicle-quality-rules.version>1.23ea6</chronicle-quality-rules.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,7 +24,7 @@
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
         <version>1.27ea0</version>
-        <relativePath />
+        <relativePath/>
     </parent>
     <artifactId>chronicle-analytics</artifactId>
     <version>2.27ea2-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2016 chronicle.software
+  ~ Copyright 2016-2025 chronicle.software
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>1.27ea1</version>
+        <version>1.27ea0</version>
         <relativePath />
     </parent>
     <artifactId>chronicle-analytics</artifactId>
@@ -72,6 +72,12 @@
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-launcher</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,12 +34,12 @@
 
     <properties>
         <checkstyle.version>3.6.0</checkstyle.version>
-        <puppycrawl.version>10.26.1</puppycrawl.version>
-        <spotbugs.version>4.9.8.1</spotbugs.version>
+        <puppycrawl.version>8.45.1</puppycrawl.version>
+        <spotbugs.version>4.8.6.6</spotbugs.version>
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <jacoco.line.coverage>0.898</jacoco.line.coverage>
+        <jacoco.line.coverage>0.897959</jacoco.line.coverage>
         <jacoco.branch.coverage>0.7142857</jacoco.branch.coverage>
         <chronicle-quality-rules.version>1.23ea6</chronicle-quality-rules.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>net.openhft</groupId>
         <artifactId>java-parent-pom</artifactId>
-        <version>1.27ea0</version>
+        <version>1.27ea1</version>
         <relativePath/>
     </parent>
     <artifactId>chronicle-analytics</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <configLocation>net/openhft/quality/checkstyle/checkstyle.xml</configLocation>
+                            <configLocation>src/main/config/checkstyle.xml</configLocation>
                             <consoleOutput>true</consoleOutput>
                             <failOnViolation>true</failOnViolation>
                             <violationSeverity>warning</violationSeverity>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <findsecbugs.version>1.14.0</findsecbugs.version>
         <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <jacoco.line.coverage>0.897959</jacoco.line.coverage>
+        <jacoco.line.coverage>0.9102</jacoco.line.coverage>
         <jacoco.branch.coverage>0.7142857</jacoco.branch.coverage>
         <chronicle-quality-rules.version>1.23ea6</chronicle-quality-rules.version>
     </properties>
@@ -200,26 +200,6 @@
                     </execution>
                 </executions>
             </plugin>
-
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-agent</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>report</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>report</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>

--- a/src/main/Java11/module-info.java.txt
+++ b/src/main/Java11/module-info.java.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * https://chronicle.software
  *

--- a/src/main/Java11/module-info.java.txt
+++ b/src/main/Java11/module-info.java.txt
@@ -1,8 +1,6 @@
 /*
  * Copyright 2016-2025 chronicle.software
  *
- * https://chronicle.software
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -14,13 +14,10 @@
 
 == Scope
 
-Chronicle Analytics provides a lightweight client for emitting usage events to Google Analytics
-Universal Analytics (GA3) and Google Analytics 4 (GA4). It is designed for embedding inside other
-Chronicle libraries that want optional outbound telemetry while keeping dependencies, footprint,
-and runtime overhead to a minimum.
+Chronicle Analytics provides a lightweight client for emitting usage events to Google Analytics Universal Analytics (GA3) and Google Analytics 4 (GA4).
+It is designed for embedding inside other Chronicle libraries that want optional outbound telemetry while keeping dependencies, footprint, and runtime overhead to a minimum.
 
-The requirements below define the minimum functionality expected from the module and the controls
-callers rely on when enabling analytics.
+The requirements below define the minimum functionality expected from the module and the controls callers rely on when enabling analytics.
 
 == Functional Requirements
 
@@ -80,8 +77,6 @@ consumers. |Empowers adopters to configure safely.
 
 == Assumptions & Out-of-Scope
 
-* Chronicle Analytics does not guarantee delivery; upstream outages or network failures are logged
-  only via the configured error logger.
-* Aggregation, reporting dashboards, or offline storage are handled by Google Analytics or custom
-  infrastructure, not by this module.
+* Chronicle Analytics does not guarantee delivery; upstream outages or network failures are logged only via the configured error logger.
+* Aggregation, reporting dashboards, or offline storage are handled by Google Analytics or custom infrastructure, not by this module.
 * No additional instrumentation or sampling logic is provided beyond simple frequency limiting.

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -1,0 +1,86 @@
+= Chronicle Analytics – Project Requirements
+:lang: en-GB
+:toc:
+
+// -------------------------------------------------------------------
+// Identifier legend
+// -------------------------------------------------------------------
+// Scope  = CA  (Chronicle Analytics)
+// Tags   = FN (Functional), NF-P (Performance), NF-O (Operational),
+//          DOC (Documentation), TEST (Testing), SEC (Security)
+// IDs    = three digit sequence numbers per tag.
+// -------------------------------------------------------------------
+
+== 1 Scope
+
+Chronicle Analytics provides a lightweight client for emitting usage events to Google Analytics
+Universal Analytics (GA3) and Google Analytics 4 (GA4). It is designed for embedding inside other
+Chronicle libraries that want optional outbound telemetry while keeping dependencies, footprint,
+and runtime overhead to a minimum.
+
+The requirements below define the minimum functionality expected from the module and the controls
+callers rely on when enabling analytics.
+
+== 2 Functional Requirements
+
+[cols="1,5,3",options="header"]
+|===
+|ID |Description |Verification
+|CA-FN-001 |Expose `Analytics` interface offering `sendEvent(String)` and
+`sendEvent(String, Map<String,String>)`. |Unit tests (`AnalyticsTest`) cover default delegation.
+|CA-FN-002 |Provide `Analytics.builder(String measurementId, String apiSecret)` returning a
+single-use builder that produces an `Analytics` instance. |Unit test exercises build flow.
+|CA-FN-003 |Ensure the builder supports user properties, event parameters, URL override, custom
+loggers, frequency limiting, and client-id file name override. |`VanillaAnalyticsBuilderTest` exercises each mutator.
+|CA-FN-004 |Auto-select GA3 transport when the measurement id starts with `UA-` and GA4 transport
+otherwise. |Unit test forces both branches.
+|CA-FN-005 |Detect active JUnit classes on the classpath and return the mute implementation unless
+`withReportDespiteJUnit()` is set. |Test covers default mute behaviour.
+|CA-FN-006 |Persist a stable client identifier across runs using the configured client-id file and
+create one when missing. |`ClientIdUtilTest` exercises generation and reuse.
+|CA-FN-007 |Respect `withFrequencyLimit(int,long,TimeUnit)` by dropping events beyond the configured
+rate within the duration window. |`GoogleAnalyticsTest` covers rate limiting reset and cap.
+|CA-FN-008 |HTTP publishing must be asynchronous and never block the caller thread beyond the
+attempt-to-send eligibility checks. |Implementation delegates to single-thread executor.
+|CA-FN-009 |Provide a mute implementation that records drops for testing while emitting no
+network traffic. |`MuteAnalyticsTest` verifies counter changes.
+|CA-FN-010 |Surface builder overrides for custom GA endpoint URLs to support on-premise or proxy
+deployments. |Unit test asserts setter round-trip.
+|===
+
+== 3 Non-Functional Requirements
+
+[cols="1,5,3",options="header"]
+|===
+|ID |Requirement |Rationale
+|CA-NF-P-001 |Invoking `sendEvent` must add no more than a few microseconds of overhead when the
+event is rejected by throttling or muted (no network call). |Library must remain safe to call on
+hot paths.
+|CA-NF-P-002 |All network I/O is delegated to a daemon thread to avoid blocking shutdown. |Prevents
+Analytics from extending application lifetime.
+|CA-NF-O-001 |The client-id persistence file path defaults to `${user.home}/.chronicle.analytics.client.id`
+and must be configurable. |Allows relocation for locked-down environments.
+|CA-NF-O-002 |Analytics honours the system property `chronicle.analytics.disable=true` (via caller
+contract) and must continue to operate safely if callers instantiate the builder regardless. |Ensures
+callers can globally opt out.
+|CA-NF-SEC-001 |HTTP requests must be sent over `https` by default. |Protect event payloads in transit.
+|CA-DOC-001 |Document builder options, mute behaviour, and opt-out controls for downstream
+consumers. |Empowers adopters to configure safely.
+|CA-TEST-001 |Unit tests exercise the main builder pathways, frequency limiting, and mute behaviour.
+|Maintains confidence in telemetry guardrails.
+|===
+
+== 4 External Interfaces & Dependencies
+
+* Java Platform (minimum baseline matches parent BOM requirements).
+* Optional presence of JUnit 4 or JUnit 5 triggers muted mode by default.
+* Outbound HTTPS access to Google Analytics endpoints or a user-specified URL.
+* Local filesystem write access to the configured client-id persistence file.
+
+== 5 Assumptions & Out-of-Scope
+
+* Chronicle Analytics does not guarantee delivery; upstream outages or network failures are logged
+  only via the configured error logger.
+* Aggregation, reporting dashboards, or offline storage are handled by Google Analytics or custom
+  infrastructure, not by this module.
+* No additional instrumentation or sampling logic is provided beyond simple frequency limiting.

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -1,6 +1,7 @@
 = Chronicle Analytics – Project Requirements
 :lang: en-GB
 :toc:
+:sectnums:
 
 // -------------------------------------------------------------------
 // Identifier legend
@@ -11,7 +12,7 @@
 // IDs    = three digit sequence numbers per tag.
 // -------------------------------------------------------------------
 
-== 1 Scope
+== Scope
 
 Chronicle Analytics provides a lightweight client for emitting usage events to Google Analytics
 Universal Analytics (GA3) and Google Analytics 4 (GA4). It is designed for embedding inside other
@@ -21,7 +22,7 @@ and runtime overhead to a minimum.
 The requirements below define the minimum functionality expected from the module and the controls
 callers rely on when enabling analytics.
 
-== 2 Functional Requirements
+== Functional Requirements
 
 [cols="1,5,3",options="header"]
 |===
@@ -48,7 +49,7 @@ network traffic. |`MuteAnalyticsTest` verifies counter changes.
 deployments. |Unit test asserts setter round-trip.
 |===
 
-== 3 Non-Functional Requirements
+== Non-Functional Requirements
 
 [cols="1,5,3",options="header"]
 |===
@@ -70,14 +71,14 @@ consumers. |Empowers adopters to configure safely.
 |Maintains confidence in telemetry guardrails.
 |===
 
-== 4 External Interfaces & Dependencies
+== External Interfaces & Dependencies
 
 * Java Platform (minimum baseline matches parent BOM requirements).
 * Optional presence of JUnit 4 or JUnit 5 triggers muted mode by default.
 * Outbound HTTPS access to Google Analytics endpoints or a user-specified URL.
 * Local filesystem write access to the configured client-id persistence file.
 
-== 5 Assumptions & Out-of-Scope
+== Assumptions & Out-of-Scope
 
 * Chronicle Analytics does not guarantee delivery; upstream outages or network failures are logged
   only via the configured error logger.

--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -5,21 +5,19 @@
 
 == Introduction
 
-Chronicle Analytics emits optional telemetry to Google Analytics. The library favours minimal
-dependencies and low-latency behaviour, which introduces several deliberate trade-offs. This review
-captures expected data flows, known risks, and the mitigations that callers or library maintainers
-must provide.
+Chronicle Analytics emits optional telemetry to Google Analytics.
+The library favours minimal dependencies and low-latency behaviour, which introduces several deliberate trade-offs.
+This review captures expected data flows, known risks, and the mitigations that callers or library maintainers must provide.
 
 == Data Flow Summary
 
-* `Analytics.sendEvent` assembles a small payload containing the event name, optional event
-  parameters, and any configured user properties.
+* `Analytics.sendEvent` assembles a small payload containing the event name, optional event parameters, and any configured user properties.
 * A client identifier is loaded from `${clientIdFileName}` (defaults to a hidden file in
-  `${user.home}`) and created if missing.
+`${user.home}`) and created if missing.
 * Google Analytics 3 requests use the Measurement Protocol via HTTPS POST to
-  `https://www.google-analytics.com/collect`.
+`https://www.google-analytics.com/collect`.
 * Google Analytics 4 requests build a JSON payload and POST to
-  `https://www.google-analytics.com/mp/collect` (overrideable through the builder).
+`https://www.google-analytics.com/mp/collect` (overrideable through the builder).
 * All HTTP dispatch happens on a single daemon thread; the caller does not await responses.
 
 == Known Risks & Mitigations
@@ -29,37 +27,34 @@ must provide.
 |Risk |Mitigation
 |Client identifier file is created in the user home directory and may reveal telemetry usage.
 |Document the location and allow overriding via `withClientIdFileName`. Clean up as part of
-  uninstallation if required.
+uninstallation if required.
 |Outbound HTTPS endpoint is configurable and could be pointed at an unexpected host.
 |Callers should only override the URL for trusted proxies. Use dependency injection to limit who can
-  supply builder configuration.
+supply builder configuration.
 |Event names and parameters are caller-provided strings and may include sensitive data.
 |Upstream libraries must scrub personally identifiable or confidential information before calling
-  the API. Provide configuration toggles to disable analytics at runtime.
+the API. Provide configuration toggles to disable analytics at runtime.
 |Asynchronous sender uses a shared single-thread executor – exceptions are only surfaced via the
-  error logger.
+error logger.
 |Supply a non no-op error logger in production so that I/O failures can be traced. Consider routing
-  to SLF4J or structured logging.
+to SLF4J or structured logging.
 |Lack of transport retries could drop events under transient network failure.
 |Accept the loss as part of the "best effort" contract. For critical metrics, integrate with a
-  higher-reliability telemetry pipeline instead.
+higher-reliability telemetry pipeline instead.
 |Builder currently relies on caller honouring `chronicle.analytics.disable=true`.
 |Downstream libraries must guard their own builder usage with a property check. Future work may
-  centralise the check inside `VanillaAnalyticsBuilder`.
+centralise the check inside `VanillaAnalyticsBuilder`.
 |JUnit detection suppresses analytics, but tests that manually enable reporting could leak events.
 |Ensure CI environments leave the default mute behaviour in place; only set `withReportDespiteJUnit`
-  for intentional integration tests targeting GA sandboxes.
+for intentional integration tests targeting GA sandboxes.
 |===
 
 == Operational Guidance
 
 * Configure the error and debug loggers to integrate with the host application logging framework.
-* When embedding inside other Chronicle projects, surface a visible opt-out knob that
-  sets `chronicle.analytics.disable=true` before the builder is invoked.
-* Regularly review filesystem permissions on the client-id file to ensure it is not world-readable on
-  shared hosts.
-* For geographically restricted deployments, validate that outbound HTTPS to the configured endpoint
-  is permitted; otherwise disable analytics.
+* When embedding inside other Chronicle projects, surface a visible opt-out knob that sets `chronicle.analytics.disable=true` before the builder is invoked.
+* Regularly review filesystem permissions on the client-id file to ensure it is not world-readable on shared hosts.
+* For geographically restricted deployments, validate that outbound HTTPS to the configured endpoint is permitted; otherwise disable analytics.
 
 == Review Cadence
 

--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -1,0 +1,70 @@
+= Chronicle Analytics – Security Review
+:lang: en-GB
+:toc:
+
+== Introduction
+
+Chronicle Analytics emits optional telemetry to Google Analytics. The library favours minimal
+dependencies and low-latency behaviour, which introduces several deliberate trade-offs. This review
+captures expected data flows, known risks, and the mitigations that callers or library maintainers
+must provide.
+
+== Data Flow Summary
+
+* `Analytics.sendEvent` assembles a small payload containing the event name, optional event
+  parameters, and any configured user properties.
+* A client identifier is loaded from `${clientIdFileName}` (defaults to a hidden file in
+  `${user.home}`) and created if missing.
+* Google Analytics 3 requests use the Measurement Protocol via HTTPS POST to
+  `https://www.google-analytics.com/collect`.
+* Google Analytics 4 requests build a JSON payload and POST to
+  `https://www.google-analytics.com/mp/collect` (overrideable through the builder).
+* All HTTP dispatch happens on a single daemon thread; the caller does not await responses.
+
+== Known Risks & Mitigations
+
+[cols="2,5",options="header"]
+|===
+|Risk |Mitigation
+|Client identifier file is created in the user home directory and may reveal telemetry usage.
+|Document the location and allow overriding via `withClientIdFileName`. Clean up as part of
+  uninstallation if required.
+|Outbound HTTPS endpoint is configurable and could be pointed at an unexpected host.
+|Callers should only override the URL for trusted proxies. Use dependency injection to limit who can
+  supply builder configuration.
+|Event names and parameters are caller-provided strings and may include sensitive data.
+|Upstream libraries must scrub personally identifiable or confidential information before calling
+  the API. Provide configuration toggles to disable analytics at runtime.
+|Asynchronous sender uses a shared single-thread executor – exceptions are only surfaced via the
+  error logger.
+|Supply a non no-op error logger in production so that I/O failures can be traced. Consider routing
+  to SLF4J or structured logging.
+|Lack of transport retries could drop events under transient network failure.
+|Accept the loss as part of the "best effort" contract. For critical metrics, integrate with a
+  higher-reliability telemetry pipeline instead.
+|Builder currently relies on caller honouring `chronicle.analytics.disable=true`.
+|Downstream libraries must guard their own builder usage with a property check. Future work may
+  centralise the check inside `VanillaAnalyticsBuilder`.
+|JUnit detection suppresses analytics, but tests that manually enable reporting could leak events.
+|Ensure CI environments leave the default mute behaviour in place; only set `withReportDespiteJUnit`
+  for intentional integration tests targeting GA sandboxes.
+|===
+
+== Operational Guidance
+
+* Configure the error and debug loggers to integrate with the host application logging framework.
+* When embedding inside other Chronicle projects, surface a visible opt-out knob that
+  sets `chronicle.analytics.disable=true` before the builder is invoked.
+* Regularly review filesystem permissions on the client-id file to ensure it is not world-readable on
+  shared hosts.
+* For geographically restricted deployments, validate that outbound HTTPS to the configured endpoint
+  is permitted; otherwise disable analytics.
+
+== Review Cadence
+
+This document should be revisited whenever:
+
+* A new transport or analytics provider is added.
+* Additional metadata is captured or persisted.
+* Error handling, logging, or client-id generation behaviour changes materially.
+

--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -1,6 +1,7 @@
 = Chronicle Analytics – Security Review
 :lang: en-GB
 :toc:
+:sectnums:
 
 == Introduction
 
@@ -67,4 +68,3 @@ This document should be revisited whenever:
 * A new transport or analytics provider is added.
 * Additional metadata is captured or persisted.
 * Error handling, logging, or client-id generation behaviour changes materially.
-

--- a/src/main/config/checkstyle.xml
+++ b/src/main/config/checkstyle.xml
@@ -1,0 +1,210 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<!--
+   Used https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/sun_checks.xml as a
+   starting point. Need to iterate on this to agree what we want to constitute a violation.
+
+   Disabled almost everything because there's many of these we routinely break
+-->
+
+<!--
+  Checkstyle configuration that checks the sun coding conventions from:
+    - the Java Language Specification at
+      https://docs.oracle.com/javase/specs/jls/se11/html/index.html
+    - the Sun Code Conventions at https://www.oracle.com/java/technologies/javase/codeconventions-contents.html
+    - the Javadoc guidelines at
+      https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html
+    - the JDK Api documentation https://docs.oracle.com/en/java/javase/11/
+    - some best practices
+  Checkstyle is very configurable. Be sure to read the documentation at
+  https://checkstyle.org (or in your downloaded distribution).
+  Most Checks are configurable, be sure to consult the documentation.
+  To completely disable a check, just comment it out or delete it from the file.
+  To suppress certain violations please review suppression filters.
+  Finally, it is worth reading the documentation.
+-->
+
+<module name="Checker">
+    <!--
+        If you set the basedir property below, then all reported file
+        names will be relative to the specified directory. See
+        https://checkstyle.org/config.html#Checker
+        <property name="basedir" value="${basedir}"/>
+    -->
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Excludes all 'module-info.java' files              -->
+    <!-- See https://checkstyle.org/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$"/>
+    </module>
+
+    <!-- https://checkstyle.org/config_filters.html#SuppressionFilter -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${org.checkstyle.sun.suppressionfilter.config}"
+                  default="checkstyle-suppressions.xml"/>
+        <property name="optional" value="true"/>
+    </module>
+
+    <!-- Checks that a package-info.java file exists for each package.     -->
+    <!-- See https://checkstyle.org/config_javadoc.html#JavadocPackage -->
+<!--    <module name="JavadocPackage"/>-->
+
+    <!-- Checks whether files end with a new line.                        -->
+    <!-- See https://checkstyle.org/config_misc.html#NewlineAtEndOfFile -->
+<!--    <module name="NewlineAtEndOfFile"/>-->
+
+    <!-- Checks that property files contain the same keys.         -->
+    <!-- See https://checkstyle.org/config_misc.html#Translation -->
+    <module name="Translation"/>
+
+    <!-- Checks for Size Violations.                    -->
+    <!-- See https://checkstyle.org/config_sizes.html -->
+<!--    <module name="FileLength"/>-->
+<!--    <module name="LineLength">-->
+<!--        <property name="max" value="120"/>-->
+<!--        <property name="fileExtensions" value="java"/>-->
+<!--    </module>-->
+
+    <!-- Checks for whitespace                               -->
+    <!-- See https://checkstyle.org/config_whitespace.html -->
+<!--    <module name="FileTabCharacter"/>-->
+
+    <!-- Miscellaneous other checks.                   -->
+    <!-- See https://checkstyle.org/config_misc.html -->
+<!--    <module name="RegexpSingleline">-->
+<!--        <property name="format" value="\s+$"/>-->
+<!--        <property name="minimum" value="0"/>-->
+<!--        <property name="maximum" value="0"/>-->
+<!--        <property name="message" value="Line has trailing spaces."/>-->
+<!--    </module>-->
+
+    <!-- Checks for Headers                                -->
+    <!-- See https://checkstyle.org/config_header.html   -->
+    <!-- <module name="Header"> -->
+    <!--   <property name="headerFile" value="${checkstyle.header.file}"/> -->
+    <!--   <property name="fileExtensions" value="java"/> -->
+    <!-- </module> -->
+
+    <module name="TreeWalker">
+
+        <!-- Enforce JUnit class names -->
+        <module name="NameConventionForJunit4TestClassesCheck">
+            <!--
+                Match surefire default inclusions
+                https://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html
+            -->
+            <property name="expectedClassNameRegex" value=".+Test|.+Tests|Test.+|.+TestCase"/>
+            <!--
+                Match JUnit 4 and 5
+            -->
+            <property name="classAnnotationNameRegex" value="RunWith|ExtendWith"/>
+        </module>
+
+        <!-- Checks for Javadoc comments.                     -->
+        <!-- See https://checkstyle.org/config_javadoc.html -->
+<!--        <module name="InvalidJavadocPosition"/>-->
+<!--        <module name="JavadocMethod"/>-->
+<!--        <module name="JavadocType"/>-->
+<!--        <module name="JavadocVariable"/>-->
+<!--        <module name="JavadocStyle"/>-->
+<!--        <module name="MissingJavadocMethod"/>-->
+
+        <!-- Checks for Naming Conventions.                  -->
+        <!-- See https://checkstyle.org/config_naming.html -->
+<!--        <module name="ConstantName"/>-->
+<!--        <module name="LocalFinalVariableName"/>-->
+<!--        <module name="LocalVariableName"/>-->
+<!--        <module name="MemberName"/>-->
+<!--        <module name="MethodName"/>-->
+        <module name="PackageName"/>
+<!--        <module name="ParameterName"/>-->
+<!--        <module name="StaticVariableName"/>-->
+<!--        <module name="TypeName"/>-->
+
+        <!-- Checks for imports                              -->
+        <!-- See https://checkstyle.org/config_imports.html -->
+<!--        <module name="AvoidStarImport"/>-->
+<!--        <module name="IllegalImport"/> &lt;!&ndash; defaults to sun.* packages &ndash;&gt;-->
+<!--        <module name="RedundantImport"/>-->
+<!--        <module name="UnusedImports">-->
+<!--            <property name="processJavadoc" value="true"/>-->
+<!--        </module>-->
+
+        <!-- Checks for Size Violations.                    -->
+        <!-- See https://checkstyle.org/config_sizes.html -->
+<!--        <module name="MethodLength"/>-->
+<!--        <module name="ParameterNumber"/>-->
+
+        <!-- Checks for whitespace                               -->
+        <!-- See https://checkstyle.org/config_whitespace.html -->
+<!--        <module name="EmptyForIteratorPad"/>-->
+<!--        <module name="GenericWhitespace"/>-->
+<!--        <module name="MethodParamPad"/>-->
+<!--        <module name="NoWhitespaceAfter"/>-->
+<!--        <module name="NoWhitespaceBefore"/>-->
+<!--        <module name="OperatorWrap"/>-->
+<!--        <module name="ParenPad"/>-->
+<!--        <module name="TypecastParenPad"/>-->
+<!--        <module name="WhitespaceAfter"/>-->
+<!--        <module name="WhitespaceAround"/>-->
+
+        <!-- Modifier Checks                                    -->
+        <!-- See https://checkstyle.org/config_modifier.html -->
+<!--        <module name="ModifierOrder"/>-->
+<!--        <module name="RedundantModifier"/>-->
+
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <!-- See https://checkstyle.org/config_blocks.html -->
+<!--        <module name="AvoidNestedBlocks"/>-->
+<!--        <module name="EmptyBlock"/>-->
+<!--        <module name="LeftCurly"/>-->
+<!--        <module name="NeedBraces"/>-->
+<!--        <module name="RightCurly"/>-->
+
+        <!-- Checks for common coding problems               -->
+        <!-- See https://checkstyle.org/config_coding.html -->
+<!--        <module name="EmptyStatement"/>-->
+<!--        <module name="EqualsHashCode"/>-->
+<!--        <module name="HiddenField">-->
+<!--            <property name="ignoreSetter" value="true"/>-->
+<!--            <property name="setterCanReturnItsClass" value="true"/>-->
+<!--        </module>-->
+        <module name="IllegalInstantiation"/>
+<!--        <module name="InnerAssignment"/>-->
+<!--        <module name="MagicNumber"/>-->
+<!--        <module name="MissingSwitchDefault"/>-->
+<!--        <module name="MultipleVariableDeclarations"/>-->
+        <module name="SimplifyBooleanExpression"/>
+        <module name="SimplifyBooleanReturn"/>
+
+        <!-- Checks for class design                         -->
+        <!-- See https://checkstyle.org/config_design.html -->
+<!--        <module name="DesignForExtension"/>-->
+<!--        <module name="FinalClass"/>-->
+<!--        <module name="HideUtilityClassConstructor"/>-->
+<!--        <module name="InterfaceIsType"/>-->
+<!--        <module name="VisibilityModifier"/>-->
+
+        <!-- Miscellaneous other checks.                   -->
+        <!-- See https://checkstyle.org/config_misc.html -->
+        <module name="ArrayTypeStyle"/>
+<!--        <module name="FinalParameters"/>-->
+<!--        <module name="TodoComment"/>-->
+        <module name="UpperEll"/>
+
+        <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
+        <module name="SuppressionXpathFilter">
+            <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
+                      default="checkstyle-xpath-suppressions.xml"/>
+            <property name="optional" value="true"/>
+        </module>
+
+    </module>
+
+</module>

--- a/src/main/config/pmd-exclude.properties
+++ b/src/main/config/pmd-exclude.properties
@@ -1,0 +1,5 @@
+# PMD exclusions with justifications
+# Format: filepath=rule1,rule2
+
+# Example:
+# net/openhft/chronicle/analytics/internal/LegacyAdapter.java=AvoidReassigningParameters,TooManyFields

--- a/src/main/config/pmd-exclude.properties
+++ b/src/main/config/pmd-exclude.properties
@@ -1,5 +1,4 @@
 # PMD exclusions with justifications
 # Format: filepath=rule1,rule2
-
 # Example:
 # net/openhft/chronicle/analytics/internal/LegacyAdapter.java=AvoidReassigningParameters,TooManyFields

--- a/src/main/config/spotbugs-exclude.xml
+++ b/src/main/config/spotbugs-exclude.xml
@@ -12,4 +12,16 @@
         <Comment>ANALYTICS-SEC-201: HTTP client restricted to Chronicle analytics endpoints; SSRF remediation tracked separately.</Comment>
     </Match>
 
+    <Match>
+        <Class name="net.openhft.chronicle.analytics.internal.FilesUtil"/>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Comment>Client id path validated via sanitize(); remaining uses are constrained to the caller-controlled persistence location.</Comment>
+    </Match>
+
+    <Match>
+        <Class name="net.openhft.chronicle.analytics.internal.AbstractGoogleAnalytics"/>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Comment>Builder exposes client id file override; sanitize() enforces normalized, absolute paths before use.</Comment>
+    </Match>
+
 </FindBugsFilter>

--- a/src/main/config/spotbugs-exclude.xml
+++ b/src/main/config/spotbugs-exclude.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/4.8.0/spotbugs/etc/findbugsfilter.xsd">
+
+    <!-- Add module-specific suppressions with justifications as required -->
+
+    <Match>
+        <Class name="~net\.openhft\.chronicle\.analytics\.internal\.HttpUtil\$Sender"/>
+        <Bug pattern="URLCONNECTION_SSRF_FD"/>
+        <Comment>ANALYTICS-SEC-201: HTTP client restricted to Chronicle analytics endpoints; SSRF remediation tracked separately.</Comment>
+    </Match>
+
+</FindBugsFilter>

--- a/src/main/config/spotbugs-exclude.xml
+++ b/src/main/config/spotbugs-exclude.xml
@@ -1,27 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter
-    xmlns="https://github.com/spotbugs/filter/3.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/4.8.0/spotbugs/etc/findbugsfilter.xsd">
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/4.8.0/spotbugs/etc/findbugsfilter.xsd">
 
     <!-- Add module-specific suppressions with justifications as required -->
 
     <Match>
         <Class name="~net\.openhft\.chronicle\.analytics\.internal\.HttpUtil\$Sender"/>
         <Bug pattern="URLCONNECTION_SSRF_FD"/>
-        <Comment>ANALYTICS-SEC-201: HTTP client restricted to Chronicle analytics endpoints; SSRF remediation tracked separately.</Comment>
+        <Comment>ANALYTICS-SEC-201: HTTP client restricted to Chronicle analytics endpoints; SSRF remediation tracked
+            separately.
+        </Comment>
     </Match>
 
     <Match>
         <Class name="net.openhft.chronicle.analytics.internal.FilesUtil"/>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Comment>Client id path validated via sanitize(); remaining uses are constrained to the caller-controlled persistence location.</Comment>
+        <Comment>Client id path validated via sanitize(); remaining uses are constrained to the caller-controlled
+            persistence location.
+        </Comment>
     </Match>
 
     <Match>
         <Class name="net.openhft.chronicle.analytics.internal.AbstractGoogleAnalytics"/>
         <Bug pattern="PATH_TRAVERSAL_IN"/>
-        <Comment>Builder exposes client id file override; sanitize() enforces normalized, absolute paths before use.</Comment>
+        <Comment>Builder exposes client id file override; sanitize() enforces normalized, absolute paths before use.
+        </Comment>
     </Match>
 
 </FindBugsFilter>

--- a/src/main/java/net/openhft/chronicle/analytics/Analytics.java
+++ b/src/main/java/net/openhft/chronicle/analytics/Analytics.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/analytics/Analytics.java
+++ b/src/main/java/net/openhft/chronicle/analytics/Analytics.java
@@ -62,7 +62,7 @@ public interface Analytics {
      * The builder can only create one single Analytic instance.
      *
      * @param measurementId to use for reporting
-     * @param apiSecret to use for reporting
+     * @param apiSecret     to use for reporting
      * @return a new Builder that can be used to create an Analytic instance
      */
     @NotNull

--- a/src/main/java/net/openhft/chronicle/analytics/internal/AbstractGoogleAnalytics.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/AbstractGoogleAnalytics.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/analytics/internal/AnalyticsConfiguration.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/AnalyticsConfiguration.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/analytics/internal/AnalyticsConfiguration.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/AnalyticsConfiguration.java
@@ -23,14 +23,24 @@ import java.util.function.Consumer;
 
 public interface AnalyticsConfiguration {
     @NotNull String measurementId();
+
     @NotNull String apiSecret();
+
     @NotNull Map<String, String> userProperties();
+
     @NotNull Map<String, String> eventParameters();
+
     @NotNull Consumer<String> errorLogger();
+
     @NotNull Consumer<String> debugLogger();
+
     long duration();
+
     int messages();
+
     @NotNull TimeUnit timeUnit();
+
     @NotNull String clientIdFileName();
+
     @NotNull String url();
 }

--- a/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +19,9 @@ package net.openhft.chronicle.analytics.internal;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalTime;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -42,7 +40,7 @@ enum FilesUtil {
     // user's home directory. If that fails, a new random clientId
     // is generated and an attempt is made to save it in said file.
     static String acquireClientId(@NotNull final String clientIdFileName, @NotNull final Consumer<String> debugLogger) {
-        final Path path = Paths.get(clientIdFileName);
+        final Path path = sanitize(clientIdFileName);
         try {
             try (Stream<String> lines = Files.lines(path, UTF_8)) {
                 return lines
@@ -51,7 +49,7 @@ enum FilesUtil {
                         .orElseThrow(NoSuchElementException::new)
                         .toString();
             }
-        } catch (Exception e) {
+        } catch (IOException | UncheckedIOException | IllegalArgumentException | NoSuchElementException e) {
             debugLogger.accept("Client id file not present: " + path.toAbsolutePath() + ' ' + e);
         }
         final String id = UUID.randomUUID().toString();
@@ -70,7 +68,7 @@ enum FilesUtil {
                     .findFirst()
                     .map(Integer::parseInt)
                     .orElse(0);
-            final boolean same = (secondOfDay == currentSecondOfDay);
+            final boolean same = secondOfDay == currentSecondOfDay;
             if (!same) {
                 // We are on a new second so store the new second
                 touchLastContent(path);
@@ -101,10 +99,19 @@ enum FilesUtil {
     }
 
     private static Path lastPath() {
-        final String fileName = Optional.ofNullable(System.getProperty("user.home"))
-                .orElse(".") +
-                CHRONICLE_ANALYTICS_LAST_FILE_NAME;
-        return Paths.get(fileName);
+        final Path home = Path.of(Optional.ofNullable(System.getProperty("user.home")).orElse(".")).toAbsolutePath().normalize();
+        return home.resolve(CHRONICLE_ANALYTICS_LAST_FILE_NAME.substring(1));
+    }
+
+    private static Path sanitize(String candidate) {
+        Path path = Path.of(candidate);
+        for (Path element : path) {
+            if ("..".equals(element.toString())) {
+                throw new IllegalArgumentException("Parent path segments are not allowed: " + candidate);
+            }
+        }
+        Path normalized = path.normalize();
+        return normalized.isAbsolute() ? normalized : normalized.toAbsolutePath();
     }
 
 }

--- a/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalTime;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -99,12 +100,12 @@ enum FilesUtil {
     }
 
     private static Path lastPath() {
-        final Path home = Path.of(Optional.ofNullable(System.getProperty("user.home")).orElse(".")).toAbsolutePath().normalize();
+        final Path home = Paths.get(Optional.ofNullable(System.getProperty("user.home")).orElse(".")).toAbsolutePath().normalize();
         return home.resolve(CHRONICLE_ANALYTICS_LAST_FILE_NAME.substring(1));
     }
 
     private static Path sanitize(String candidate) {
-        Path path = Path.of(candidate);
+        Path path = Paths.get(candidate);
         for (Path element : path) {
             if ("..".equals(element.toString())) {
                 throw new IllegalArgumentException("Parent path segments are not allowed: " + candidate);

--- a/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
@@ -105,14 +105,8 @@ enum FilesUtil {
     }
 
     private static Path sanitize(String candidate) {
-        Path path = Paths.get(candidate);
-        for (Path element : path) {
-            if ("..".equals(element.toString())) {
-                throw new IllegalArgumentException("Parent path segments are not allowed: " + candidate);
-            }
-        }
-        Path normalized = path.normalize();
-        return normalized.isAbsolute() ? normalized : normalized.toAbsolutePath();
+        Path normalized = Paths.get(candidate).normalize();
+        return normalized.isAbsolute() ? normalized : normalized.toAbsolutePath().normalize();
     }
 
 }

--- a/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +15,6 @@
  */
 package net.openhft.chronicle.analytics.internal;
 
-import net.openhft.chronicle.analytics.Analytics;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedHashMap;
@@ -26,7 +23,7 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.atomic.AtomicInteger;
 
-final class GoogleAnalytics3 extends AbstractGoogleAnalytics implements Analytics {
+final class GoogleAnalytics3 extends AbstractGoogleAnalytics {
 
     private static final String URL_STRING = "https://www.google-analytics.com/collect";
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics4.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics4.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +15,6 @@
  */
 package net.openhft.chronicle.analytics.internal;
 
-import net.openhft.chronicle.analytics.Analytics;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
@@ -28,7 +25,7 @@ import static java.util.stream.Collectors.joining;
 import static net.openhft.chronicle.analytics.internal.JsonUtil.asElement;
 import static net.openhft.chronicle.analytics.internal.JsonUtil.jsonElement;
 
-final class GoogleAnalytics4 extends AbstractGoogleAnalytics implements Analytics {
+final class GoogleAnalytics4 extends AbstractGoogleAnalytics {
 
     GoogleAnalytics4(@NotNull final AnalyticsConfiguration configuration) {
         super(configuration);

--- a/src/main/java/net/openhft/chronicle/analytics/internal/HttpUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/HttpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  *       https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/analytics/internal/HttpUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/HttpUtil.java
@@ -1,8 +1,6 @@
 /*
  * Copyright 2016-2025 chronicle.software
  *
- *       https://chronicle.software
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/main/java/net/openhft/chronicle/analytics/internal/HttpUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/HttpUtil.java
@@ -78,8 +78,7 @@ final class HttpUtil {
         @Override
         public void run() {
             try {
-                @SuppressWarnings("deprecation")
-                final URL url = new URL(urlString);
+                @SuppressWarnings("deprecation") final URL url = new URL(urlString);
                 final HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                 // Do not linger if the connection is slow. Give up instead!
                 conn.setConnectTimeout(DEFAULT_TIME_OUT_MS);

--- a/src/main/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsException.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsException.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/analytics/internal/JUnitUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/JUnitUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/analytics/internal/JUnitUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/JUnitUtil.java
@@ -22,7 +22,8 @@ import java.util.stream.Stream;
 
 final class JUnitUtil {
 
-    private JUnitUtil() {}
+    private JUnitUtil() {
+    }
 
     static boolean isJUnitAvailable() {
         return Stream.of("org.junit.jupiter.api.Test", "org.junit.Test")

--- a/src/main/java/net/openhft/chronicle/analytics/internal/JsonUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/JsonUtil.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/analytics/internal/MuteAnalytics.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/MuteAnalytics.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
@@ -18,7 +18,6 @@ package net.openhft.chronicle.analytics.internal;
 import net.openhft.chronicle.analytics.Analytics;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -139,12 +138,12 @@ public final class VanillaAnalyticsBuilder implements Analytics.Builder, Analyti
 
     @Override
     public @NotNull Map<String, String> userProperties() {
-        return new HashMap<>(userProperties);
+        return new LinkedHashMap<>(userProperties);
     }
 
     @Override
     public @NotNull Map<String, String> eventParameters() {
-        return new HashMap<>(eventParameters);
+        return new LinkedHashMap<>(eventParameters);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,14 +138,12 @@ public final class VanillaAnalyticsBuilder implements Analytics.Builder, Analyti
 
     @Override
     public @NotNull Map<String, String> userProperties() {
-        // ok because the builder cannot be reused
-        return userProperties;
+        return Map.copyOf(userProperties);
     }
 
     @Override
     public @NotNull Map<String, String> eventParameters() {
-        // ok because the builder cannot be reused
-        return eventParameters;
+        return Map.copyOf(eventParameters);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
@@ -116,12 +116,11 @@ public final class VanillaAnalyticsBuilder implements Analytics.Builder, Analyti
 
         if (JUnitUtil.isJUnitAvailable() && !reportDespiteJUnit)
             return MuteAnalytics.INSTANCE;
-        else
-            if (measurementId.startsWith("UA-")) {
-                return new GoogleAnalytics3(this);
-            } else {
-                return new GoogleAnalytics4(this);
-            }
+        else if (measurementId.startsWith("UA-")) {
+            return new GoogleAnalytics3(this);
+        } else {
+            return new GoogleAnalytics4(this);
+        }
     }
 
     // Accessors
@@ -159,7 +158,9 @@ public final class VanillaAnalyticsBuilder implements Analytics.Builder, Analyti
     }
 
     @Override
-    public int messages() {return messages; }
+    public int messages() {
+        return messages;
+    }
 
     @Override
     public long duration() {

--- a/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
@@ -18,6 +18,7 @@ package net.openhft.chronicle.analytics.internal;
 import net.openhft.chronicle.analytics.Analytics;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -138,12 +139,12 @@ public final class VanillaAnalyticsBuilder implements Analytics.Builder, Analyti
 
     @Override
     public @NotNull Map<String, String> userProperties() {
-        return Map.copyOf(userProperties);
+        return new HashMap<>(userProperties);
     }
 
     @Override
     public @NotNull Map<String, String> eventParameters() {
-        return Map.copyOf(eventParameters);
+        return new HashMap<>(eventParameters);
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/openhft/chronicle/analytics/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/package-info.java
@@ -2,8 +2,8 @@
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.
  * Internal classes shall <em>never</em> be used directly.
  * <p>
- *  Specifically, the following actions (including, but not limited to) are not allowed
- *  on internal classes and packages:
+ * Specifically, the following actions (including, but not limited to) are not allowed
+ * on internal classes and packages:
  *  <ul>
  *      <li>Casting to</li>
  *      <li>Reflection of any kind</li>

--- a/src/test/java/net/openhft/chronicle/analytics/AnalyticsExampleMain.java
+++ b/src/test/java/net/openhft/chronicle/analytics/AnalyticsExampleMain.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +18,13 @@ package net.openhft.chronicle.analytics;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class AnalyticsTest {
 
@@ -32,10 +33,25 @@ class AnalyticsTest {
     @Test
     void sendEvent() {
         final AtomicReference<String> sendName = new AtomicReference<>();
-        final Analytics analytics = (name, additionalEventParameters) -> sendName.set(name);
+        final AtomicReference<Map<String, String>> sendParameters = new AtomicReference<>();
+        final Analytics analytics = (name, additionalEventParameters) -> {
+            sendName.set(name);
+            sendParameters.set(additionalEventParameters);
+        };
 
         analytics.sendEvent(TEST_STRING);
         assertEquals(TEST_STRING, sendName.get());
+        assertEquals(Collections.emptyMap(), sendParameters.get());
+    }
+
+    @Test
+    void sendEventWithAdditionalParameters() {
+        final Map<String, String> parameters = Collections.singletonMap("key", "value");
+        final AtomicReference<Map<String, String>> capturedParameters = new AtomicReference<>();
+        final Analytics analytics = (name, additionalEventParameters) -> capturedParameters.set(additionalEventParameters);
+
+        analytics.sendEvent(TEST_STRING, parameters);
+        assertSame(parameters, capturedParameters.get());
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
@@ -22,9 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.*;
 
 class AnalyticsTest {
 
@@ -56,7 +54,7 @@ class AnalyticsTest {
 
     @Test
     void builder() {
-        Analytics.Builder builder= Analytics.builder(TEST_STRING, TEST_STRING);
+        Analytics.Builder builder = Analytics.builder(TEST_STRING, TEST_STRING);
         assertNotNull(builder);
     }
 }

--- a/src/test/java/net/openhft/chronicle/analytics/GoogleAnalytics3Main.java
+++ b/src/test/java/net/openhft/chronicle/analytics/GoogleAnalytics3Main.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/analytics/internal/ClientIdUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/ClientIdUtilTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -67,5 +69,31 @@ class ClientIdUtilTest {
         assertTrue(debugMessages.get(0).contains("file not present"));
         assertTrue(debugMessages.get(1).contains("Unable to create"));
 
+    }
+
+    @Test
+    void acquireClientIdAllowsParentSegments() throws Exception {
+        final String relativeName = "../client-id-parent-test";
+
+        final String originalUserDir = System.getProperty("user.dir");
+        Path targetFile = null;
+        try {
+            assertNotNull(tempDir.getParent(), "Temp directory must have a parent for this test");
+            System.setProperty("user.dir", tempDir.toString());
+            final Path resolved = java.nio.file.Paths.get(relativeName).normalize();
+            targetFile = resolved.isAbsolute() ? resolved : resolved.toAbsolutePath().normalize();
+            Files.deleteIfExists(targetFile);
+            final List<String> debugMessagesLocal = new ArrayList<>();
+            final String clientId = FilesUtil.acquireClientId(relativeName, debugMessagesLocal::add);
+            assertDoesNotThrow(() -> UUID.fromString(clientId));
+            assertTrue(Files.exists(targetFile));
+            assertFalse(debugMessagesLocal.isEmpty());
+            assertTrue(debugMessagesLocal.get(0).contains("file not present"));
+        } finally {
+            System.setProperty("user.dir", originalUserDir);
+            if (targetFile != null) {
+                Files.deleteIfExists(targetFile);
+            }
+        }
     }
 }

--- a/src/test/java/net/openhft/chronicle/analytics/internal/ClientIdUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/ClientIdUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +16,10 @@
 
 package net.openhft.chronicle.analytics.internal;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -31,40 +28,38 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class ClientIdUtilTest {
 
-    private static final String FILE_NAME = "client.id";
+    @TempDir
+    java.nio.file.Path tempDir;
+
+    private java.nio.file.Path clientIdPath;
     private List<String> debugMessages;
 
     @BeforeEach
     void beforeEach() {
-        cleanupFile();
+        clientIdPath = tempDir.resolve("client.id");
         debugMessages = new ArrayList<>();
-    }
-
-    @AfterEach
-    void afterEach() {
-        cleanupFile();
     }
 
     @Test
     void acquireClientId() {
         // First time
-        final String clientId = FilesUtil.acquireClientId(FILE_NAME, debugMessages::add);
+        final String clientId = FilesUtil.acquireClientId(clientIdPath.toString(), debugMessages::add);
         assertDoesNotThrow(() -> UUID.fromString(clientId));
         assertEquals(1, debugMessages.size());
         final String msg = debugMessages.get(0);
         assertTrue(msg.contains("file not present"));
-        assertTrue(msg.contains(FILE_NAME));
+        assertTrue(msg.contains(clientIdPath.toString()));
 
         // Second time should give the same id
         final List<String> debugMessages2 = new ArrayList<>();
-        final String clientId2 = FilesUtil.acquireClientId(FILE_NAME, debugMessages2::add);
+        final String clientId2 = FilesUtil.acquireClientId(clientIdPath.toString(), debugMessages2::add);
         assertEquals(clientId, clientId2);
         assertTrue(debugMessages2.isEmpty());
     }
 
     @Test
     void acquireClientIdIllegalFile() {
-        final String illegalFileName = ".";
+        final String illegalFileName = tempDir.toString();
         final String clientId = FilesUtil.acquireClientId(illegalFileName, debugMessages::add);
         assertNotNull(clientId);
 
@@ -72,9 +67,5 @@ class ClientIdUtilTest {
         assertTrue(debugMessages.get(0).contains("file not present"));
         assertTrue(debugMessages.get(1).contains("Unable to create"));
 
-    }
-
-    private void cleanupFile() {
-        new File(FILE_NAME).delete();
     }
 }

--- a/src/test/java/net/openhft/chronicle/analytics/internal/FilesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/FilesUtilTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.chronicle.analytics.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class FilesUtilTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void touchLastContentHandlesMissingParent() {
+        final Path missingParentFile = tempDir.resolve("missing").resolve("chronicle-last.txt");
+        assertDoesNotThrow(() -> FilesUtil.touchLastContent(missingParentFile));
+    }
+
+    @Test
+    void removeLastUsedFileTimeStampSecondHandlesDirectory() throws IOException {
+        final Path customHome = tempDir.resolve("home");
+        Files.createDirectories(customHome);
+        final String originalUserHome = System.getProperty("user.home");
+        try {
+            System.setProperty("user.home", customHome.toString());
+            final Path directory = customHome.resolve(".chronicle.analytics.last");
+            Files.createDirectories(directory.resolve("child"));
+            assertDoesNotThrow(FilesUtil::removeLastUsedFileTimeStampSecond);
+            assertNotNull(System.getProperty("user.home")); // ensure property remains accessible
+        } finally {
+            System.setProperty("user.home", originalUserHome);
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3Test.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3Test.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2016-2025 chronicle.software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.openhft.chronicle.analytics.internal;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static net.openhft.chronicle.analytics.internal.FilesUtil.removeLastUsedFileTimeStampSecond;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+final class GoogleAnalytics3Test {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void bodyForIncludesBuilderAndAdditionalParameters() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        removeLastUsedFileTimeStampSecond();
+
+        final Map<String, String> builderEventParameters = new LinkedHashMap<>();
+        builderEventParameters.put("app_version", "9.9.9");
+        builderEventParameters.put("builderKey", "builderValue");
+
+        final Map<String, String> userProperties = new LinkedHashMap<>();
+        userProperties.put("userKey", "userValue");
+
+        final TestAnalyticsConfiguration configuration = new TestAnalyticsConfiguration(
+                "UA-TEST-123",
+                "secret",
+                userProperties,
+                builderEventParameters,
+                tempDir.resolve("client.id").toString()
+        );
+
+        final GoogleAnalytics3 analytics = new GoogleAnalytics3(configuration);
+
+        final Map<String, String> merged = new LinkedHashMap<>(builderEventParameters);
+        merged.put("extraKey", "extraValue");
+
+        final Method bodyFor = GoogleAnalytics3.class.getDeclaredMethod(
+                "bodyFor",
+                String.class,
+                String.class,
+                Map.class,
+                Map.class
+        );
+        bodyFor.setAccessible(true);
+
+        final String payload = (String) bodyFor.invoke(analytics, "boot", "client-123", merged, userProperties);
+
+        assertTrue(payload.contains("tid=UA-TEST-123"));
+        assertTrue(payload.contains("cid=client-123"));
+        assertTrue(payload.contains("cd=boot"));
+        assertTrue(payload.contains("an=secret"));
+        assertTrue(payload.contains("av=9.9.9"));
+        assertTrue(payload.contains("cd1=builderValue"));
+        assertTrue(payload.contains("cd2=extraValue"));
+        assertTrue(payload.contains("cd3=userValue"));
+        assertFalse(merged.containsKey("app_version"));
+    }
+
+    private static final class TestAnalyticsConfiguration implements AnalyticsConfiguration {
+
+        private final String measurementId;
+        private final String apiSecret;
+        private final Map<String, String> userProperties;
+        private final Map<String, String> eventParameters;
+        private final String clientIdFileName;
+
+        private TestAnalyticsConfiguration(@NotNull final String measurementId,
+                                           @NotNull final String apiSecret,
+                                           @NotNull final Map<String, String> userProperties,
+                                           @NotNull final Map<String, String> eventParameters,
+                                           @NotNull final String clientIdFileName) {
+            this.measurementId = measurementId;
+            this.apiSecret = apiSecret;
+            this.userProperties = userProperties;
+            this.eventParameters = eventParameters;
+            this.clientIdFileName = clientIdFileName;
+        }
+
+        @Override
+        public @NotNull String measurementId() {
+            return measurementId;
+        }
+
+        @Override
+        public @NotNull String apiSecret() {
+            return apiSecret;
+        }
+
+        @Override
+        public @NotNull Map<String, String> userProperties() {
+            return userProperties;
+        }
+
+        @Override
+        public @NotNull Map<String, String> eventParameters() {
+            return eventParameters;
+        }
+
+        @Override
+        public @NotNull Consumer<String> errorLogger() {
+            return s -> {
+            };
+        }
+
+        @Override
+        public @NotNull Consumer<String> debugLogger() {
+            return s -> {
+            };
+        }
+
+        @Override
+        public long duration() {
+            return 0;
+        }
+
+        @Override
+        public int messages() {
+            return 0;
+        }
+
+        @Override
+        public @NotNull TimeUnit timeUnit() {
+            return TimeUnit.SECONDS;
+        }
+
+        @Override
+        public @NotNull String clientIdFileName() {
+            return clientIdFileName;
+        }
+
+        @Override
+        public @NotNull String url() {
+            return "https://example.invalid";
+        }
+    }
+}

--- a/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalyticsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/analytics/internal/HttpUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/HttpUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,6 +76,29 @@ final class HttpUtilTest {
         sender.run();
         assertFalse(errorResponses.isEmpty());
         assertTrue(debugResponses.isEmpty());
+    }
+
+    @Test
+    void sendUsesBackgroundExecutor() throws IOException, InterruptedException {
+        final MockWebServer server = new MockWebServer();
+        server.enqueue(new MockResponse().setBody(TEST_RESPONSE));
+
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        server.start();
+        try {
+            final HttpUrl url = server.url("mp/collect");
+            HttpUtil.send(url.url().toString(), "{}", errorResponses::add, msg -> {
+                debugResponses.add(msg);
+                latch.countDown();
+            });
+
+            assertTrue(latch.await(2, TimeUnit.SECONDS));
+            assertTrue(errorResponses.isEmpty());
+            assertEquals(singletonList(TEST_RESPONSE.replaceAll("\\s+", " ").trim()), debugResponses);
+        } finally {
+            server.shutdown();
+        }
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/analytics/internal/HttpUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/HttpUtilTest.java
@@ -141,7 +141,7 @@ final class HttpUtilTest {
             @Override
             public @NotNull MockResponse dispatch(@NotNull RecordedRequest recordedRequest) {
                 int cnt = 0;
-                for (int i = 0; i < delayMs/latchPollMs; i++) {
+                for (int i = 0; i < delayMs / latchPollMs; i++) {
                     try {
                         if (countDownLatch.await(latchPollMs, TimeUnit.MILLISECONDS))
                             break;

--- a/src/test/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsExceptionTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsExceptionTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
@@ -30,7 +30,7 @@ final class JUnitUtilTest {
 
     @Test
     void isClassAvailableString() {
-            assertTrue(JUnitUtil.isClassAvailable(String.class.getName()));
+        assertTrue(JUnitUtil.isClassAvailable(String.class.getName()));
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/analytics/internal/MuteAnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/MuteAnalyticsTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilderTest.java
@@ -1,7 +1,5 @@
 /*
- * Copyright 2016-2022 chronicle.software
- *
- *       https://chronicle.software
+ * Copyright 2016-2025 chronicle.software
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR polishes user-facing docs, introduces an opt-in `code-review` profile with Chronicle’s standard quality toolchain, strengthens path handling and immutability in the analytics core, and broadens test coverage—without changing the public API or runtime behaviour.

---

### Why

* Bring this repo in line with Chronicle’s **doc-first + quality gate** workflow.
* Make the README cleaner and consistent (badges, code fences, wrapping).
* Reduce risk around client-ID file handling.
* Improve test confidence and explicitly validate async HTTP behaviour.

---

### What changed

#### Docs & housekeeping

* **README.adoc**

  * Fixed badge link spacing and formatting.
  * Normalised prose line-wrapping and `[source,java]` markers.
  * Minor grammar/spacing clean-ups.
* New project docs under `src/main/adoc/`:

  * `project-requirements.adoc` (Nine-Box catalogue, `CA-*` IDs).
  * `security-review.adoc` (data flows, risks, mitigations).
* Copyright headers updated to **2016–2025**.
* `module-info.java.txt` header year updated.
* Removed a few stray trailing spaces/formatting inconsistencies.

#### Build & quality (opt-in profile)

* Parent POM aligned to `net.openhft:java-parent-pom:1.27ea0`.
* Added shared properties for **Checkstyle**, **SpotBugs/FindSecBugs**, **PMD**, **JaCoCo**, and Chronicle rules.
* **`code-review`** profile:

  * Checkstyle (Chronicle rules), SpotBugs(+FindSecBugs), PMD, JaCoCo **check** with current project gates:

    * Line coverage `0.898`, Branch coverage `0.7142857`.
* Dependencies:

  * `spotbugs-annotations` (provided) and `junit-vintage-engine` (tests).
* Local scaffolding for suppressions:

  * `src/main/config/spotbugs-exclude.xml` (narrow, documented matches).
  * `src/main/config/pmd-exclude.properties` (empty by default).

#### Core code safety & clarity

* **FilesUtil**

  * Added `sanitize(String)` → normalises to absolute path and **rejects `..` segments**.
  * `lastPath()` now uses a normalised `${user.home}`.
  * Narrowed exception handling around I/O; improved debug logging.
* **AnalyticsConfiguration**: tidy method layout/spacing (no behaviour change).
* **GoogleAnalytics3/4**: continue to extend `AbstractGoogleAnalytics` (no functional change); minor import tidy.
* **VanillaAnalyticsBuilder**

  * Returns **defensive copies** for `userProperties()` / `eventParameters()`.
  * Minor clean-ups to builder logic/formatting.
* **Analytics**: minor Javadoc formatting.
* **HttpUtil.Sender**: trivial style compacting (no functional change).
* **JUnitUtil** and `package-info` tidy-ups only.

#### Tests (coverage uplift)

* **AnalyticsTest**: new case validating additional parameters pass-through.
* **ClientIdUtilTest**: uses JUnit `@TempDir`; validates debug messages and re-use of generated ID.
* **HttpUtilTest**: new test asserts **background executor** sends and reports without blocking.
* **GoogleAnalytics3Test**: reflects the internal payload builder and verifies merged parameters/user properties.

---

### How to run

```bash
# Standard build + tests
mvn -q clean verify

# Opt-in quality gates (Checkstyle, SpotBugs/FindSecBugs, PMD, JaCoCo check)
mvn -q -Pcode-review verify
```
