### PR TITLE
Migrate Chronicle Analytics tests to JUnit 5

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>chronicle-analytics</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1774259938437</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
@@ -91,5 +91,4 @@ enum FilesUtil {
                 CHRONICLE_ANALYTICS_LAST_FILE_NAME;
         return Paths.get(fileName);
     }
-
 }

--- a/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
@@ -7,8 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class AnalyticsTest {
 

--- a/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
@@ -24,7 +24,7 @@ class AnalyticsTest {
 
     @Test
     void builder() {
-        Analytics.Builder builder= Analytics.builder(TEST_STRING, TEST_STRING);
+        Analytics.Builder builder = Analytics.builder(TEST_STRING, TEST_STRING);
         assertNotNull(builder);
     }
 }

--- a/src/test/java/net/openhft/chronicle/analytics/internal/FilesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/FilesUtilTest.java
@@ -10,8 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class FilesUtilTest {
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3Test.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3Test.java
@@ -16,8 +16,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static net.openhft.chronicle.analytics.internal.FilesUtil.removeLastUsedFileTimeStampSecond;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class GoogleAnalytics3Test {
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalyticsTest.java
@@ -4,7 +4,6 @@
 package net.openhft.chronicle.analytics.internal;
 
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assume;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalTime;
@@ -15,8 +14,8 @@ import java.util.function.Function;
 
 import static net.openhft.chronicle.analytics.internal.FilesUtil.removeLastUsedFileTimeStampSecond;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
-//@Disabled(/* failing test https://teamcity.chronicle.software/buildConfiguration/Chronicle_BuildAll_Build/677499?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true */)
 final class GoogleAnalyticsTest {
 
     @Test
@@ -92,7 +91,7 @@ final class GoogleAnalyticsTest {
         /* This test would fail if run concurrently from two different JVMs,
         therefore it's only run if the googleAnalytics instance is not muted (update in agreement with Rob)
         */
-        Assume.assumeFalse(googleAnalytics.muted);
+        assumeFalse(googleAnalytics.muted);
         for (int i = 0; i < messages; i++) {
             assertTrue(googleAnalytics.attemptToSend(), "Round " + i);
         }

--- a/src/test/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsExceptionTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsExceptionTest.java
@@ -5,7 +5,7 @@ package net.openhft.chronicle.analytics.internal;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class InternalAnalyticsExceptionTest {
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
@@ -5,8 +5,7 @@ package net.openhft.chronicle.analytics.internal;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class JUnitUtilTest {
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
@@ -16,7 +16,7 @@ final class JUnitUtilTest {
 
     @Test
     void isClassAvailableString() {
-            assertTrue(JUnitUtil.isClassAvailable(String.class.getName()));
+        assertTrue(JUnitUtil.isClassAvailable(String.class.getName()));
     }
 
     @Test

--- a/src/test/java/net/openhft/chronicle/analytics/internal/MuteAnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/MuteAnalyticsTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 final class MuteAnalyticsTest {
 


### PR DESCRIPTION
## Summary
Migrate Chronicle Analytics tests to Jupiter, remove dead disabled markers, and align the workspace metadata touched by the branch.

## Included Work
- Remove dead disabled marker comments
- Migrate Chronicle Analytics tests to Jupiter
- Add Eclipse metadata for Chronicle Analytics

## Changed Areas
- `.project`
- `.settings/org.eclipse.m2e.core.prefs`
- `src/test`

## Notes
- Compared against `develop` after refreshing `origin/develop` on 2026-03-24.
- Full repository test suites were not rerun during this bulk PR creation pass.
