### PR TITLE
docs: bump copyright year end to 2026

### DIFF
--- a/noop/pom.xml
+++ b/noop/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/noop/src/main/java/net/openhft/chronicle/analytics/package-info.java
+++ b/noop/src/main/java/net/openhft/chronicle/analytics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package contains the NOOP API for the chronicle-analytics library.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+    Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
 
 -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <packaging>bundle</packaging>
 
     <properties>
+        <license.year>2013-2026</license.year>
         <jacoco.line.coverage>0.89</jacoco.line.coverage>
         <jacoco.branch.coverage>0.72</jacoco.branch.coverage>
     </properties>

--- a/src/main/Java11/module-info.java.txt
+++ b/src/main/Java11/module-info.java.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 chronicle.software
+ * Copyright 2016-2026 chronicle.software
  *
  * https://chronicle.software
  *

--- a/src/main/java/net/openhft/chronicle/analytics/Analytics.java
+++ b/src/main/java/net/openhft/chronicle/analytics/Analytics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/AbstractGoogleAnalytics.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/AbstractGoogleAnalytics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/AnalyticsConfiguration.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/AnalyticsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/FilesUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics4.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/HttpUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/HttpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsException.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/JUnitUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/JUnitUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/JsonUtil.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/JsonUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/MuteAnalytics.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/MuteAnalytics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/main/java/net/openhft/chronicle/analytics/internal/package-info.java
+++ b/src/main/java/net/openhft/chronicle/analytics/internal/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package and any and all sub-packages contains strictly internal classes for this Chronicle library.

--- a/src/main/java/net/openhft/chronicle/analytics/package-info.java
+++ b/src/main/java/net/openhft/chronicle/analytics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 /**
  * This package contains the public API for the chronicle-analytics library.

--- a/src/test/java/net/openhft/chronicle/analytics/AnalyticsExampleMain.java
+++ b/src/test/java/net/openhft/chronicle/analytics/AnalyticsExampleMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics;
 

--- a/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/AnalyticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics;
 

--- a/src/test/java/net/openhft/chronicle/analytics/GoogleAnalytics3Main.java
+++ b/src/test/java/net/openhft/chronicle/analytics/GoogleAnalytics3Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/ClientIdUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/ClientIdUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/FilesUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/FilesUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3Test.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalytics3Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/GoogleAnalyticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/HttpUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/HttpUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsExceptionTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/InternalAnalyticsExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/JUnitUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/MuteAnalyticsTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/MuteAnalyticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 

--- a/src/test/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilderTest.java
+++ b/src/test/java/net/openhft/chronicle/analytics/internal/VanillaAnalyticsBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2025 chronicle.software; SPDX-License-Identifier: Apache-2.0
+ * Copyright 2013-2026 chronicle.software; SPDX-License-Identifier: Apache-2.0
  */
 package net.openhft.chronicle.analytics.internal;
 


### PR DESCRIPTION
## Summary
- Rolls `Copyright YYYY-20XX chronicle.software` / `higherfrequencytrading.com` forward so the end year matches the current calendar year (2026).
- Non-chronicle copyrights (third-party headers, etc.) are intentionally left alone.
- Adds a local `license.year=2013-2026` override in the project POM so `license-maven-plugin` validates the updated headers correctly on CI.
- Behaviour-neutral; no logic changes.

## Test plan
- [ ] Visual diff review - expect header year updates plus the `license.year` POM override.
- [ ] `mvn -DskipTests license:check`
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)