### PR TITLE
docs: update stale GitHub branch references (master -> develop/ea)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,7 @@ Per Minborg
 
 image:https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-analytics/badge.svg[Maven Central,link=https://maven-badges.herokuapp.com/maven-central/net.openhft/chronicle-analytics]
 image:https://javadoc-badge.appspot.com/net.openhft/chronicle-analytics.svg?label=javadoc[JavaDoc, link=https://www.javadoc.io/doc/net.openhft/chronicle-analytics]
-image:https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000[License, link=https://github.com/OpenHFT/Chronicle-Analytics/blob/master/LICENSE]
+image:https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000[License, link=https://github.com/OpenHFT/Chronicle-Analytics/blob/develop/LICENSE]
 image:https://img.shields.io/gitter/room/OpenHFT/Lobby.svg?style=popout[link="https://gitter.im/OpenHFT/Lobby"]
 
 This library provides remote ingress to Google Analytics 4, allowing data, such as usage-statistics, to be collected for Java applications.The data can subsequently be analysed using


### PR DESCRIPTION
## Summary
- Own-repo and OpenHFT repos that default to `develop` now use `/blob/develop/` and `/tree/develop/`.
- Chronicle-Bytes references move to `/blob/ea/` (its default branch).
- OpenHFT/RFC references remain on `master` (still its default).

## Test plan
- [ ] Clicking the updated links lands on a valid file/tree page.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)