### PR TITLE
docs: replace above-U+00FF characters with 8-bit equivalents

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,14 +88,14 @@ Configuration of the builder may be done using the following methods:
 | Return type | Method | Description
 
 |Analytics |build()|Creates and returns a new Analytics instance for this Builder.
-|Builder   |putEventParameter​(String key, String value)|Associates the provided value with the provided key in this builder's event parameters.
-|Builder   |putUserProperty​(String key, String value)|Associates the provided value with the provided key in this builder's user properties.
-|Builder   |withClientIdFileName​(String clientIdFileName)|Specifies a custom file name to use when storing a persistent client id used to identify returning users.
-|Builder   |withDebugLogger​(Consumer<String> debugLogger)|Specifies a custom logger that will receive debug messages.
-|Builder   |withErrorLogger​(Consumer<String> errorLogger)|Specifies a custom logger that will receive error messages.
-|Builder   |withFrequencyLimit​(long duration, TimeUnit timeUnit)|Limits the frequency by which events can be sent upstream to Google Analytics.
+|Builder   |putEventParameter(String key, String value)|Associates the provided value with the provided key in this builder's event parameters.
+|Builder   |putUserProperty(String key, String value)|Associates the provided value with the provided key in this builder's user properties.
+|Builder   |withClientIdFileName(String clientIdFileName)|Specifies a custom file name to use when storing a persistent client id used to identify returning users.
+|Builder   |withDebugLogger(Consumer<String> debugLogger)|Specifies a custom logger that will receive debug messages.
+|Builder   |withErrorLogger(Consumer<String> errorLogger)|Specifies a custom logger that will receive error messages.
+|Builder   |withFrequencyLimit(long duration, TimeUnit timeUnit)|Limits the frequency by which events can be sent upstream to Google Analytics.
 |Builder   |withReportDespiteJUnit()|Specifies that reporting shall be made even though JUnit test classes are available to the classloader.
-|Builder   |withUrl​(String url)|Specifies a custom URL to use when connecting to Google Analytics.
+|Builder   |withUrl(String url)|Specifies a custom URL to use when connecting to Google Analytics.
 |===
 
 NOTE: All parameters and return values are non-null.
@@ -112,8 +112,8 @@ Once we have obtained an Analytic instance, we can send events up stream to Goog
 |===
 | Return type | Method | Description
 
-|void|sendEvent​(String name)|Sends an event to Google Analytics as identified by the provided event `name`.
-|void|sendEvent​(String name, Map<String,​String> additionalEventParameters)|Sends an event to Google Analytics as identified by the provided event `name`, including the provided `additionalEventParameters` in the event.
+|void|sendEvent(String name)|Sends an event to Google Analytics as identified by the provided event `name`.
+|void|sendEvent(String name, Map<String,String> additionalEventParameters)|Sends an event to Google Analytics as identified by the provided event `name`, including the provided `additionalEventParameters` in the event.
 |===
 
 NOTE: All parameters are non-null.

--- a/src/main/adoc/project-requirements.adoc
+++ b/src/main/adoc/project-requirements.adoc
@@ -1,4 +1,4 @@
-= Chronicle Analytics – Project Requirements
+= Chronicle Analytics - Project Requirements
 :lang: en-GB
 :toc:
 :sectnums:

--- a/src/main/adoc/security-review.adoc
+++ b/src/main/adoc/security-review.adoc
@@ -1,4 +1,4 @@
-= Chronicle Analytics – Security Review
+= Chronicle Analytics - Security Review
 :lang: en-GB
 :toc:
 :sectnums:
@@ -34,7 +34,7 @@ supply builder configuration.
 |Event names and parameters are caller-provided strings and may include sensitive data.
 |Upstream libraries must scrub personally identifiable or confidential information before calling
 the API. Provide configuration toggles to disable analytics at runtime.
-|Asynchronous sender uses a shared single-thread executor – exceptions are only surfaced via the
+|Asynchronous sender uses a shared single-thread executor - exceptions are only surfaced via the
 error logger.
 |Supply a non no-op error logger in production so that I/O failures can be traced. Consider routing
 to SLF4J or structured logging.


### PR DESCRIPTION
## Summary
Documentation is expected to stay within 8-bit (1-255) so characters outside that range are folded to their closest Latin-1/ASCII forms:

| Before | After |
|--------|-------|
| en-dash, non-breaking hyphen, figure dash | `-` |
| em-dash, horizontal bar | `--` |
| ellipsis | `...` |
| zero-width space / joiners / direction marks | *removed* |
| smart single quotes `'` `'` | `'` |
| smart double quotes `"` `"` | `"` |
| `<=`, `>=` | `<=`, `>=` |

Latin-1 characters (micro sign, non-breaking space, etc.) are left alone.

## Test plan
- [ ] Rendered output still reads naturally.
- [ ] No code semantics affected (text-only files).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)