### PR TITLE
docs: AsciiDoc corrections in Chronicle-Analytics README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ image:https://javadoc-badge.appspot.com/net.openhft/chronicle-analytics.svg?labe
 image:https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000[License, link=https://github.com/OpenHFT/Chronicle-Analytics/blob/master/LICENSE]
 image:https://img.shields.io/gitter/room/OpenHFT/Lobby.svg?style=popout[link="https://gitter.im/OpenHFT/Lobby"]
 
-This library provides remote ingress to Google Analytics 4, allowing data, such as usage-statistics, to be collected for Java applications.The data can subsequently be analysed using
+This library provides remote ingress to Google Analytics 4, allowing data, such as usage-statistics, to be collected for Java applications. The data can subsequently be analysed using
 a variety of tools available from Google and other providers.
 
 Here is a short Java snippet showing how one could use the library to send a Google Analytics event
@@ -37,17 +37,18 @@ This jar is redundant but can help ensure this jar does nothing.
 
 To disable this jar include the following in Maven: 
 
-[script,xml]
+[source,xml]
 ----
 <dependency>
     <groupId>net.openhft</groupId>
     <artifactId>chronicle-analytics</artifactId>
     <version>0.20.0</version>
+</dependency>
 ----
 
 To disable this library with Gradle, use: 
 
-[script,xml]
+[source,xml]
 ----
 configurations {
     implementation {
@@ -63,7 +64,7 @@ The library and its use is further described hereunder.
 === API overview
 
 Applications will create and use instances of `Analytics`.
-Analytic instances are created using a builder pattern that optionally allows various custom parameters to be set, after which a new instance is created by invoking a `build()` method:
+Analytics instances are created using a builder pattern that optionally allows various custom parameters to be set, after which a new instance is created by invoking a `build()` method:
 
 [source,java]
 ----
@@ -104,9 +105,9 @@ NOTE: Invoking `withUrl("https://www.google-analytics.com/debug/mp/collect")` al
 
 NOTE: See the link:https://javadoc.io/doc/net.openhft/chronicle-analytics/latest/index.html[JavaDocs] for more details on the methods above.
 
-=== Analytic methods
+=== Analytics methods
 
-Once we have obtained an Analytic instance, we can send events up stream to Google using the following methods:
+Once we have obtained an Analytic instance, we can send events upstream to Google using the following methods:
 
 .Analytics Methods
 |===
@@ -125,7 +126,7 @@ NOTE: See the link:https://javadoc.io/doc/net.openhft/chronicle-analytics/latest
 The following example sets up an analytics instance with the *event parameter* `app_version = 1.4.2` and perhaps the *user properties*
 `os_name = Linux`, `os_version = 4.18.0.147.2.1.2l8_1.x86_64` and `java_runtime_version = 1.8.0_272-b10` depending on the environment used:
 
-[source, java]
+[source,java]
 ----
 public class AnalyticsExampleMain {
 


### PR DESCRIPTION
## Summary
- `[script,xml]` -> `[source,xml]` (x2; "script" is not a valid AsciiDoc source attribute).
- `[source, java]` -> `[source,java]` (style consistency).
- Close an orphan XML dependency example by adding the missing `</dependency>` before the fence so the snippet is copy-paste valid.
- "Analytic instances"/"Analytic methods" -> "Analytics ..." to match the library name.
- "up stream" -> "upstream".
- "applications.The" -> "applications. The".

## Test plan
- [ ] Render the README - the XML block is now well-formed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)